### PR TITLE
Fix alternative for deprecated

### DIFF
--- a/src/components/render-plugin-doc/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc/render-plugin-doc.tsx
@@ -21,7 +21,7 @@ class PluginDoc {
     notes?: string[];
     deprecated?: {
         removed_in?: string;
-        alternate?: string;
+        alternative?: string;
         why?: string;
     };
 }
@@ -380,8 +380,8 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
 
                 <div>
                     <b>Alternative: </b>
-                    {deprecated.why
-                        ? doc.deprecated.why
+                    {deprecated.alternative
+                        ? doc.deprecated.alternative
                         : 'No alternatives specified.'}
                 </div>
             </React.Fragment>


### PR DESCRIPTION
Fixes https://github.com/ansible/galaxy_ng/issues/300

Steps to reproduce:
- add namespace `arista`
- upload collection `eos`
- go to Documentation and click on `eos-interface`

Before:
<img width="1658" alt="Screenshot 2020-07-15 at 13 55 38" src="https://user-images.githubusercontent.com/9210860/87542221-e2c84a00-c6a2-11ea-9456-c8da1547c393.png">
After:
<img width="1644" alt="Screenshot 2020-07-20 at 17 00 02" src="https://user-images.githubusercontent.com/9210860/87952757-7d14fd00-caaa-11ea-8881-5e1d2c2b5089.png">

Notes: 
 - Run `ansible-hub-ui` outside container. Otherwise `npm link` will have no effect. 
 - I fixed following errors locally as I wasn't sure it's not just my monkey patch build problem. If you see it too ping me to push it.
```
TS2339: Property 'props' does not exist on type 'RenderPluginDoc'.
```
or
```
ERROR in [at-loader] ./node_modules/@ansible/galaxy-doc-builder/src/components/render-plugin-doc/render-plugin-doc.tsx:118:47 
    TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
```